### PR TITLE
Bump kube to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "cluster-api-rs"
-version = "1.9.6"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0468e98cb9e5502d8a9b3776a06208daaa87afc25405c60a2a8e70c270dc0439"
+checksum = "d87e63f482c27fefd3a4ed7a4b2a4d1c2ba24a218914a3fd37202b4fd06108bf"
 dependencies = [
  "k8s-openapi",
  "kube",
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "fleet-api-rs"
-version = "0.12.2"
+version = "0.12.3-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf006ba285434d5dd6982f861f03454bd5e4ab976f5048767780a58e13185d44"
+checksum = "f70503e55ef758a654a14209cbfc7f134de499f83e29edbfd3785b7c21564457"
 dependencies = [
  "k8s-openapi",
  "kube",
@@ -1297,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1307,6 +1307,7 @@ dependencies = [
  "http 1.3.1",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1593,23 +1594,22 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c75b990324f09bef15e791606b7b7a296d02fc88a344f6eba9390970a870ad5"
+checksum = "aa60a41b57ae1a0a071af77dbcf89fc9819cfe66edaf2beeb204c34459dcf0b2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "schemars",
  "serde",
- "serde-value",
  "serde_json",
 ]
 
 [[package]]
 name = "kube"
-version = "0.99.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a4eb20010536b48abe97fec37d23d43069bcbe9686adcf9932202327bc5ca6e"
+checksum = "1b49c39074089233c2bb7b1791d1b6c06c84dbab26757491fad9d233db0d432f"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1620,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.99.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc2ed952042df20d15ac2fe9614d0ec14b6118eab89633985d4b36e688dccf1"
+checksum = "e199797b1b08865041c9c698f0d11a91de0a8143e808b71e250cd4a1d7ce2b9f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1657,11 +1657,12 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.99.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff0d0793db58e70ca6d689489183816cb3aa481673e7433dc618cf7e8007c675"
+checksum = "1bdefbba89dea2d99ea822a1d7cd6945535efbfb10b790056ee9284bf9e698e7"
 dependencies = [
  "chrono",
+ "derive_more",
  "form_urlencoded",
  "http 1.3.1",
  "json-patch",
@@ -1675,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.99.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c562f58dc9f7ca5feac8a6ee5850ca221edd6f04ce0dd2ee873202a88cd494c9"
+checksum = "8e609a3633689a50869352a3c16e01d863b6137863c80eeb038383d5ab9f83bf"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1689,14 +1690,13 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.99.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88f34cfab9b4bd8633062e0e85edb81df23cb09f159f2e31c60b069ae826ffdc"
+checksum = "1d4bd8a4554786f8f9a87bfa977fb7dbaa1d7f102a30477338b044b65de29d8e"
 dependencies = [
  "ahash",
  "async-broadcast",
  "async-stream",
- "async-trait",
  "backon",
  "educe",
  "futures",
@@ -1729,9 +1729,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "litemap"
@@ -2687,9 +2687,9 @@ checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ rand = { version = "0.9", features = ["small_rng"] }
 actix-web = "4.10.2"
 futures = "0.3.28"
 tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread", "process"] }
-k8s-openapi = { version = "0.24", features = ["latest", "schemars"] }
-kube = { version = "0.99.0", features = [
+k8s-openapi = { version = "0.25", features = ["latest", "schemars"] }
+kube = { version = "1.0.0", features = [
     "runtime",
     "client",
     "derive",
@@ -58,8 +58,8 @@ thiserror = "2.0.11"
 anyhow = "1.0.98"
 base64 = "0.22.1"
 clap = { version = "4.5.38", features = ["derive"] }
-cluster-api-rs = "1.9.6"
-fleet-api-rs = "0.12.2"
+cluster-api-rs = "1.10.0"
+fleet-api-rs = "0.12.3-rc.1"
 async-broadcast = "0.7.2"
 pin-project = "1.1.10"
 async-stream = "0.3.6"

--- a/src/api/capi_cluster.rs
+++ b/src/api/capi_cluster.rs
@@ -123,8 +123,7 @@ impl Cluster {
                     host_network: config.host_network,
                     agent_env_vars: config.agent_env_vars.clone(),
                     ..Default::default()
-                }
-                .into(),
+                },
                 false => fleet_api_rs::fleet_cluster::ClusterSpec {
                     kube_config_secret: Some(format!("{}-kubeconfig", self.name_any())),
                     agent_namespace: config.agent_install_namespace().into(),
@@ -132,8 +131,7 @@ impl Cluster {
                     host_network: config.host_network,
                     agent_env_vars: config.agent_env_vars.clone(),
                     ..Default::default()
-                }
-                .into(),
+                },
             },
             #[cfg(not(feature = "agent-initiated"))]
             spec: fleet_api_rs::fleet_cluster::ClusterSpec {
@@ -191,8 +189,7 @@ impl Cluster {
             metadata: self.into(),
             spec: ClusterRegistrationTokenSpec {
                 ttl: Some("1h".into()),
-            }
-            .into(),
+            },
             ..Default::default()
         }
         .into()

--- a/src/api/fleet_addon_config.rs
+++ b/src/api/fleet_addon_config.rs
@@ -8,7 +8,7 @@ use k8s_openapi::{
 use kube::{
     api::{ObjectMeta, TypeMeta},
     core::{ParseExpressionError, Selector},
-    KubeSchema, CustomResource, Resource,
+    CustomResource, KubeSchema, Resource,
 };
 use schemars::JsonSchema;
 use serde::{ser, Deserialize, Serialize};
@@ -26,7 +26,7 @@ pub const EXPERIMENTAL_HELM_OPS: &str = "EXPERIMENTAL_HELM_OPS";
     group = "addons.cluster.x-k8s.io",
     version = "v1alpha1",
     status = "FleetAddonConfigStatus",
-    validation = "self.metadata.name == 'fleet-addon-config'",
+    validation = "self.metadata.name == 'fleet-addon-config'"
 )]
 #[serde(rename_all = "camelCase")]
 pub struct FleetAddonConfigSpec {

--- a/src/api/fleet_addon_config.rs
+++ b/src/api/fleet_addon_config.rs
@@ -8,7 +8,7 @@ use k8s_openapi::{
 use kube::{
     api::{ObjectMeta, TypeMeta},
     core::{ParseExpressionError, Selector},
-    CELSchema, CustomResource, Resource,
+    KubeSchema, CustomResource, Resource,
 };
 use schemars::JsonSchema;
 use serde::{ser, Deserialize, Serialize};
@@ -20,13 +20,13 @@ pub const EXPERIMENTAL_OCI_STORAGE: &str = "EXPERIMENTAL_OCI_STORAGE";
 pub const EXPERIMENTAL_HELM_OPS: &str = "EXPERIMENTAL_HELM_OPS";
 
 /// This provides a config for fleet addon functionality
-#[derive(CustomResource, Deserialize, Serialize, Clone, Default, Debug, CELSchema)]
+#[derive(CustomResource, Deserialize, Serialize, Clone, Default, Debug, KubeSchema)]
 #[kube(
     kind = "FleetAddonConfig",
     group = "addons.cluster.x-k8s.io",
     version = "v1alpha1",
     status = "FleetAddonConfigStatus",
-    rule = Rule::new("self.metadata.name == 'fleet-addon-config'"),
+    validation = "self.metadata.name == 'fleet-addon-config'",
 )]
 #[serde(rename_all = "camelCase")]
 pub struct FleetAddonConfigSpec {

--- a/src/controllers/cluster.rs
+++ b/src/controllers/cluster.rs
@@ -16,8 +16,6 @@ use kube::client::scope;
 use kube::runtime::watcher::{self, Config};
 use kube::{api::ResourceExt, runtime::controller::Action, Resource};
 use kube::{Api, Client};
-#[cfg(feature = "agent-initiated")]
-use rand::distr::{Alphanumeric, SampleString as _};
 use serde::Serialize;
 use serde_json::Value;
 use tracing::info;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -24,8 +24,7 @@ async fn init_tracer() -> opentelemetry_sdk::trace::Tracer {
     let builder = SdkTracerProvider::builder();
     #[cfg(feature = "telemetry")]
     let builder = builder.with_batch_exporter(exporter);
-    builder.build()
-        .tracer("addon-provider-fleet")
+    builder.build().tracer("addon-provider-fleet")
 }
 
 /// Initialize tracing


### PR DESCRIPTION
- Update all API dependencies to latest versions with 1.0.0 kube version.
- Replace `CELSchema` with `KubeSchema`

Prerequisite for https://github.com/rancher/cluster-api-addon-provider-fleet/issues/44