### PR TITLE
chore: Update dependencies, add clippy CI, and cleanup code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,3 +123,10 @@ jobs:
         with:
           name: artifacts-import-rke2-${{ matrix.display_name }}
           path: _out/gather
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -W clippy::pedantic

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.9.1",
  "sha1",
  "smallvec",
  "tokio",
@@ -567,12 +567,12 @@ dependencies = [
  "hyper",
  "k8s-openapi",
  "kube",
- "opentelemetry 0.29.1",
+ "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry_sdk 0.29.0",
+ "opentelemetry_sdk",
  "pin-project",
  "prometheus",
- "rand",
+ "rand 0.9.1",
  "schemars",
  "serde",
  "serde_json",
@@ -1612,7 +1612,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tracing",
 ]
@@ -1843,43 +1843,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.12",
- "tracing",
-]
-
-[[package]]
 name = "opentelemetry-http"
-version = "0.30.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.3.1",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "reqwest",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.30.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
 dependencies = [
+ "futures-core",
  "http 1.3.1",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry_sdk",
  "prost",
  "reqwest",
  "thiserror 2.0.12",
@@ -1890,12 +1878,12 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.30.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
 dependencies = [
- "opentelemetry 0.30.0",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
  "tonic",
 ]
@@ -1910,28 +1898,12 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "glob",
- "opentelemetry 0.29.1",
+ "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.9.1",
  "serde_json",
  "thiserror 2.0.12",
  "tracing",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry 0.30.0",
- "percent-encoding",
- "rand",
- "serde_json",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2185,12 +2157,33 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2200,7 +2193,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2299,7 +2301,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2892,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2910,7 +2912,27 @@ dependencies = [
  "prost",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2924,9 +2946,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.9.0",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
  "tokio-util",
@@ -3031,8 +3051,8 @@ checksum = "fd8e764bd6f5813fd8bebc3117875190c5b0415be8f7f8059bffb6ecd979c444"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.29.1",
- "opentelemetry_sdk 0.29.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,12 +112,11 @@ dependencies = [
 
 [[package]]
 name = "actix-service"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
+checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
 dependencies = [
  "futures-core",
- "paste",
  "pin-project-lite",
 ]
 
@@ -203,12 +202,12 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -300,12 +299,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -361,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.87"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -384,9 +383,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backon"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970d91570c01a8a5959b36ad7dd1c30642df24b6b3068710066f6809f7033bb7"
+checksum = "fd0b50b1b78dbadd44ab18b3c794e496f3a139abb9fbc27d9c94c4eebbb96496"
 dependencies = [
  "fastrand",
  "gloo-timers",
@@ -395,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -405,7 +404,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -422,9 +421,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
@@ -463,16 +462,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytestring"
@@ -485,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
 dependencies = [
  "jobserver",
  "libc",
@@ -644,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -694,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -704,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -718,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -729,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -799,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -851,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -867,9 +860,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flate2"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -896,9 +889,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1010,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1021,14 +1014,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1067,7 +1060,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1076,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1086,7 +1079,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1101,9 +1094,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1157,13 +1150,13 @@ dependencies = [
 
 [[package]]
 name = "hostname"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
+checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
 dependencies = [
  "cfg-if",
  "libc",
- "windows",
+ "windows-link",
 ]
 
 [[package]]
@@ -1200,12 +1193,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.3.1",
  "http-body",
  "pin-project-lite",
@@ -1232,7 +1225,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.8",
+ "h2 0.4.10",
  "http 1.3.1",
  "http-body",
  "httparse",
@@ -1245,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-http-proxy"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d06dbdfbacf34d996c6fb540a71a684a7aae9056c71951163af8a8a4c07b9a4"
+checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
 dependencies = [
  "bytes",
  "futures-util",
@@ -1265,11 +1258,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
 dependencies = [
- "futures-util",
  "http 1.3.1",
  "hyper",
  "hyper-util",
@@ -1297,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1317,14 +1309,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -1340,21 +1333,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1364,30 +1358,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1395,65 +1369,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1475,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1502,12 +1463,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -1540,10 +1501,11 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -1700,7 +1662,7 @@ dependencies = [
  "backon",
  "educe",
  "futures",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "hostname",
  "json-patch",
  "k8s-openapi",
@@ -1735,9 +1697,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "local-channel"
@@ -1768,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matchers"
@@ -1795,23 +1757,23 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1853,6 +1815,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl-probe"
@@ -2007,14 +1975,8 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -2034,9 +1996,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -2045,9 +2007,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2055,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2068,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -2116,6 +2078,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,18 +2094,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -2199,12 +2170,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -2232,14 +2209,14 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags",
 ]
@@ -2296,9 +2273,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2333,13 +2310,13 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2353,9 +2330,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustls"
-version = "0.23.23"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "log",
  "once_cell",
@@ -2402,15 +2379,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2419,9 +2399,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -2498,7 +2478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2589,7 +2569,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2615,7 +2595,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "itoa",
  "ryu",
  "serde",
@@ -2635,9 +2615,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2661,9 +2641,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -2679,15 +2659,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2713,9 +2693,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.99"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2733,9 +2713,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2794,9 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -2809,15 +2789,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2825,9 +2805,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2898,9 +2878,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2944,7 +2924,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -2957,9 +2937,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
 dependencies = [
  "base64 0.22.1",
  "bitflags",
@@ -3146,12 +3126,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3192,9 +3166,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -3313,58 +3287,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.52.0"
+name = "windows-core"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-core",
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.52.0"
+name = "windows-implement"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
- "windows-targets",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
- "windows-strings",
- "windows-targets",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3373,7 +3371,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3382,7 +3380,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3391,14 +3389,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3408,10 +3422,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3420,10 +3446,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3432,10 +3470,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3444,37 +3494,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -3484,9 +3540,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3496,19 +3552,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3543,10 +3598,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3555,9 +3621,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3575,18 +3641,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.3"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3051792fbdc2e1e143244dc28c60f73d8470e93f3f9cbd0ead44da5ed802722"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.14+zstd.1.5.7"
+version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cluster-api-addon-provider-fleet"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 default-run = "controller"
 license = "Apache-2.0"
 publish = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.19", features = ["json", "env-filter"] }
 tracing-opentelemetry = "0.30.0"
 opentelemetry = { version = "0.29.1" }
-opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic", "logs"]}
+opentelemetry-otlp = { version = "0.29.0", features = ["grpc-tonic", "logs"]}
 opentelemetry_sdk = { version = "0.29.0" }
 thiserror = "2.0.11"
 anyhow = "1.0.98"

--- a/config/crds/fleet-addon-config.yaml
+++ b/config/crds/fleet-addon-config.yaml
@@ -25,11 +25,11 @@ spec:
                 description: |-
                   Enable Cluster config funtionality.
 
-                  This will create Fleet Cluster for each Cluster with the same name. In case the cluster specifies topology.class, the name of the ClusterClass will be added to the Fleet Cluster labels.
+                  This will create Fleet Cluster for each Cluster with the same name. In case the cluster specifies topology.class, the name of the `ClusterClass` will be added to the Fleet Cluster labels.
                 nullable: true
                 properties:
                   agentEnvVars:
-                    description: AgentEnvVars are extra environment variables to be added to the agent deployment.
+                    description: '`AgentEnvVars` are extra environment variables to be added to the agent deployment.'
                     items:
                       description: EnvVar represents an environment variable present in a Container.
                       properties:
@@ -152,7 +152,7 @@ spec:
                     nullable: true
                     type: array
                   applyClassGroup:
-                    description: Apply a ClusterGroup for a ClusterClass referenced from a different namespace.
+                    description: Apply a `ClusterGroup` for a `ClusterClass` referenced from a different namespace.
                     nullable: true
                     type: boolean
                   hostNetwork:
@@ -248,7 +248,7 @@ spec:
                 description: |-
                   Enable clusterClass controller functionality.
 
-                  This will create Fleet ClusterGroups for each ClusterClaster with the same name.
+                  This will create Fleet `ClusterGroups` for each `ClusterClaster` with the same name.
                 nullable: true
                 properties:
                   patchResource:
@@ -272,7 +272,7 @@ spec:
                     nullable: true
                     properties:
                       configMap:
-                        description: FeaturesConfigMap references a ConfigMap where to apply feature flags. If a ConfigMap is referenced, the controller will update it instead of upgrading the Fleet chart.
+                        description: '`FeaturesConfigMap` references a `ConfigMap` where to apply feature flags. If a `ConfigMap` is referenced, the controller will update it instead of upgrading the Fleet chart.'
                         nullable: true
                         properties:
                           ref:

--- a/justfile
+++ b/justfile
@@ -44,6 +44,10 @@ fmt:
 test-unit:
   cargo test
 
+# run clippy
+clippy:
+  cargo clippy --all-targets --all-features --fix --allow-dirty -- -W clippy::pedantic
+
 # compile for musl (for docker image)
 compile features="":  _create-out-dir
   #!/usr/bin/env bash

--- a/src/api/capi_clusterclass.rs
+++ b/src/api/capi_clusterclass.rs
@@ -1,16 +1,28 @@
+#[allow(unused_imports)]
+mod prelude {
+    pub use k8s_openapi::api::core::v1::ObjectReference;
+    pub use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
+    pub use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
+    pub use kube::CustomResource;
+    pub use schemars::JsonSchema;
+    pub use serde::{Deserialize, Serialize};
+    pub use std::collections::BTreeMap;
+}
 use cluster_api_rs::capi_clusterclass::{ClusterClassSpec, ClusterClassStatus};
-use kube::{
-    api::{ObjectMeta, TypeMeta},
-    Resource,
-};
-use serde::{Deserialize, Serialize};
 
-#[derive(Resource, Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
-#[resource(inherit = cluster_api_rs::capi_clusterclass::ClusterClass)]
-pub struct ClusterClass {
-    #[serde(flatten, default)]
-    pub types: Option<TypeMeta>,
-    pub metadata: ObjectMeta,
-    pub spec: ClusterClassSpec,
-    pub status: Option<ClusterClassStatus>,
+use self::prelude::*;
+
+/// `ClusterClassProxy` describes the desired state of the `ClusterClass`.
+#[derive(CustomResource, Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[kube(
+    group = "cluster.x-k8s.io",
+    version = "v1beta1",
+    kind = "ClusterClass",
+    plural = "clusterclasses"
+)]
+#[kube(namespaced)]
+#[kube(status = "ClusterClassStatus")]
+pub struct ClusterClassProxy {
+    #[serde(flatten)]
+    pub proxy: ClusterClassSpec,
 }

--- a/src/api/fleet_addon_config.rs
+++ b/src/api/fleet_addon_config.rs
@@ -32,13 +32,13 @@ pub const EXPERIMENTAL_HELM_OPS: &str = "EXPERIMENTAL_HELM_OPS";
 pub struct FleetAddonConfigSpec {
     /// Enable clusterClass controller functionality.
     ///
-    /// This will create Fleet ClusterGroups for each ClusterClaster with the same name.
+    /// This will create Fleet `ClusterGroups` for each `ClusterClaster` with the same name.
     pub cluster_class: Option<ClusterClassConfig>,
 
     /// Enable Cluster config funtionality.
     ///
     /// This will create Fleet Cluster for each Cluster with the same name.
-    /// In case the cluster specifies topology.class, the name of the ClusterClass
+    /// In case the cluster specifies topology.class, the name of the `ClusterClass`
     /// will be added to the Fleet Cluster labels.
     pub cluster: Option<ClusterConfig>,
 
@@ -52,14 +52,14 @@ pub struct FleetAddonConfigSpec {
 impl Default for FleetAddonConfig {
     fn default() -> Self {
         Self {
-            metadata: Default::default(),
+            metadata: ObjectMeta::default(),
             spec: FleetAddonConfigSpec {
                 cluster_class: Some(ClusterClassConfig::default()),
                 cluster: Some(ClusterConfig::default()),
                 config: Some(FleetConfig::default()),
                 ..Default::default()
             },
-            status: Default::default(),
+            status: Option::default(),
         }
     }
 }
@@ -98,7 +98,7 @@ impl Default for ClusterClassConfig {
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ClusterConfig {
-    /// Apply a ClusterGroup for a ClusterClass referenced from a different namespace.
+    /// Apply a `ClusterGroup` for a `ClusterClass` referenced from a different namespace.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub apply_class_group: Option<bool>,
 
@@ -128,7 +128,7 @@ pub struct ClusterConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub host_network: Option<bool>,
 
-    /// AgentEnvVars are extra environment variables to be added to the agent deployment.
+    /// `AgentEnvVars` are extra environment variables to be added to the agent deployment.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_env_vars: Option<Vec<ClusterAgentEnvVars>>,
 
@@ -178,7 +178,7 @@ impl Display for FleetChartValues {
 }
 
 impl FleetAddonConfigSpec {
-    /// Returns reference to FeatureGates if defined.
+    /// Returns reference to `FeatureGates` if defined.
     pub(crate) fn feature_gates(&self) -> Option<&FeatureGates> {
         self.config.as_ref()?.feature_gates.as_ref()
     }
@@ -237,7 +237,7 @@ impl ClusterConfig {
     }
 }
 
-/// NamingStrategy is controlling Fleet cluster naming
+/// `NamingStrategy` is controlling Fleet cluster naming
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, Default)]
 pub struct NamingStrategy {
     /// Specify a prefix for the Cluster name, applied to created Fleet cluster
@@ -251,12 +251,12 @@ impl Default for ClusterConfig {
         Self {
             apply_class_group: Some(true),
             set_owner_references: Some(true),
-            naming: Default::default(),
+            naming: Option::default(),
             agent_namespace: AGENT_NAMESPACE.to_string().into(),
             host_network: Some(true),
             #[cfg(feature = "agent-initiated")]
             agent_initiated: Some(true),
-            selectors: Default::default(),
+            selectors: Selectors::default(),
             patch_resource: Some(true),
             agent_env_vars: None,
             agent_tolerations: None,
@@ -281,7 +281,7 @@ pub struct FleetConfig {
 impl Default for FleetConfig {
     fn default() -> Self {
         Self {
-            server: Default::default(),
+            server: Option::default(),
             feature_gates: Some(FeatureGates::default()),
             bootstrap_local_cluster: None,
         }
@@ -313,7 +313,7 @@ impl Display for FeatureGates {
 }
 
 impl FeatureGates {
-    /// Returns reference to a ConfigMap if defined.
+    /// Returns reference to a `ConfigMap` if defined.
     pub(crate) fn config_map_ref(&self) -> Option<&ObjectReference> {
         self.config_map.as_ref()?.reference.as_ref()
     }
@@ -358,8 +358,8 @@ impl Default for FeatureGates {
     }
 }
 
-/// FeaturesConfigMap references a ConfigMap where to apply feature flags.
-/// If a ConfigMap is referenced, the controller will update it instead of upgrading the Fleet chart.
+/// `FeaturesConfigMap` references a `ConfigMap` where to apply feature flags.
+/// If a `ConfigMap` is referenced, the controller will update it instead of upgrading the Fleet chart.
 #[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct FeaturesConfigMap {
@@ -368,7 +368,7 @@ pub struct FeaturesConfigMap {
     pub reference: Option<ObjectReference>,
 }
 
-/// FleetChartValues represents Fleet chart values.
+/// `FleetChartValues` represents Fleet chart values.
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FleetChartValues {
@@ -377,7 +377,7 @@ pub struct FleetChartValues {
     pub other: Value,
 }
 
-/// EnvironmentVariable is a simple name/value pair.
+/// `EnvironmentVariable` is a simple name/value pair.
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EnvironmentVariable {
@@ -404,7 +404,7 @@ pub enum Install {
 }
 
 impl Install {
-    /// Perform version normalization for comparison with `helm search` app_version output
+    /// Perform version normalization for comparison with `helm search` `app_version` output
     pub(crate) fn normalized(self) -> Self {
         match self {
             Install::FollowLatest(_) => self,
@@ -436,6 +436,7 @@ pub struct InstallOptions {
 }
 
 impl NamingStrategy {
+    #[must_use]
     pub fn apply(&self, name: Option<String>) -> Option<String> {
         name.map(|name| match &self.prefix {
             Some(prefix) => prefix.clone() + &name,
@@ -570,7 +571,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_sync_config_map() {
-        let want_fleet_data = r#"extraEnv:
+        let want_fleet_data = r"extraEnv:
 - name: EXPERIMENTAL_HELM_OPS
   value: 'true'
 - name: foo
@@ -579,7 +580,7 @@ mod tests {
   value: 'true'
 foo:
   bar: foobar
-"#;
+";
         let fleet_data = r#"extraEnv:
 - name: EXPERIMENTAL_HELM_OPS
   value: "false"
@@ -596,17 +597,17 @@ foo:
 
         feature_gates.merge_features(&mut data);
 
-        assert_eq!(want_fleet_data.to_string(), data.fleet.to_string())
+        assert_eq!(want_fleet_data.to_string(), data.fleet.to_string());
     }
 
     #[tokio::test]
     async fn test_sync_empty_config_map() {
-        let want_fleet_data = r#"extraEnv:
+        let want_fleet_data = r"extraEnv:
 - name: EXPERIMENTAL_HELM_OPS
   value: 'false'
 - name: EXPERIMENTAL_OCI_STORAGE
   value: 'false'
-"#;
+";
         let mut data = FleetSettingsSpec::default();
         let feature_gates = FeatureGates {
             experimental_oci_storage: false,
@@ -616,6 +617,6 @@ foo:
 
         feature_gates.merge_features(&mut data);
 
-        assert_eq!(want_fleet_data.to_string(), data.fleet.to_string())
+        assert_eq!(want_fleet_data.to_string(), data.fleet.to_string());
     }
 }

--- a/src/api/fleet_addon_config.rs
+++ b/src/api/fleet_addon_config.rs
@@ -183,7 +183,7 @@ impl FleetAddonConfigSpec {
         self.config.as_ref()?.feature_gates.as_ref()
     }
 
-    /// Returns the value of bootstrap_local_cluster if defined.
+    /// Returns the value of `bootstrap_local_cluster` if defined.
     pub(crate) fn bootstrap(&self) -> Option<bool> {
         self.config.as_ref()?.bootstrap_local_cluster
     }
@@ -332,7 +332,7 @@ impl FeatureGates {
                 name: EXPERIMENTAL_HELM_OPS.to_string(),
                 value: self.experimental_helm_ops.to_string(),
             }),
-        };
+        }
 
         match env_map
             .iter_mut()
@@ -343,7 +343,7 @@ impl FeatureGates {
                 name: EXPERIMENTAL_OCI_STORAGE.to_string(),
                 value: self.experimental_oci_storage.to_string(),
             }),
-        };
+        }
     }
 }
 

--- a/src/controllers/addon_config.rs
+++ b/src/controllers/addon_config.rs
@@ -347,7 +347,7 @@ impl FleetAddonConfig {
             }
             (Some(_), Some(_), Install::FollowLatest(false) | Install::Version(_)) => {}
             (_, _, _) => return Ok(Some(Action::requeue(Duration::from_secs(10)))),
-        };
+        }
 
         let installed_chart_meta = FleetChart::get_metadata("fleet").await?;
         let search_result = chart
@@ -407,7 +407,7 @@ impl FleetAddonConfig {
             }
             (Some(_), Some(_), Install::Version(_)) => {}
             (_, _, _) => return Ok(Some(Action::requeue(Duration::from_secs(10)))),
-        };
+        }
 
         Ok(None)
     }

--- a/src/controllers/cluster.rs
+++ b/src/controllers/cluster.rs
@@ -142,7 +142,7 @@ impl FleetBundle for FleetClusterBundle {
                 let class_namespace = mapping.namespace().unwrap_or_default();
                 let cluster_namespace = mapping.name_any();
                 info!("Updated BundleNamespaceMapping for cluster {cluster_name} between class namespace: {class_namespace} and cluster namespace: {cluster_namespace}");
-            };
+            }
         }
 
         if self.config.cluster_patch_enabled() {
@@ -169,7 +169,7 @@ impl FleetBundle for FleetClusterBundle {
                 )
                 .await
                 .map_err(ClusterSyncError::GroupPatchError)?;
-            };
+            }
         }
 
         Ok(Action::await_change())

--- a/src/controllers/cluster.rs
+++ b/src/controllers/cluster.rs
@@ -10,7 +10,9 @@ use crate::api::fleet_clustergroup::ClusterGroup;
 use crate::controllers::addon_config::to_dynamic_event;
 use futures::StreamExt as _;
 use k8s_openapi::api::core::v1::Namespace;
-use kube::api::{ApiResource, ListParams, Object, PatchParams};
+use kube::api::{
+    ApiResource, DeleteParams, DynamicObject, GroupVersionKind, ListParams, PatchParams,
+};
 
 use kube::client::scope;
 use kube::runtime::watcher::{self, Config};
@@ -46,9 +48,9 @@ struct TemplateValues {
     #[serde(rename = "Cluster")]
     cluster: Cluster,
     #[serde(rename = "ControlPlane")]
-    control_plane: Object<Value, Value>,
+    control_plane: DynamicObject,
     #[serde(rename = "InfrastructureCluster")]
-    infrastructure_cluster: Object<Value, Value>,
+    infrastructure_cluster: DynamicObject,
 }
 
 impl TemplateSources {
@@ -62,22 +64,49 @@ impl TemplateSources {
 
         cluster.status = None;
         cluster.meta_mut().managed_fields = None;
+        cluster.meta_mut().resource_version = None;
 
-        let mut control_plane: Object<Value, Value> = client
-            .fetch(self.0.spec.control_plane_ref.as_ref()?)
-            .await
-            .ok()?;
+        let reference = self.0.spec.proxy.control_plane_ref.as_ref()?;
+        let api_version = reference.api_version.as_ref()?;
+        let (group, version) = api_version.split_once('/').unwrap_or(("", api_version));
+        let resource = ApiResource::from_gvk(&GroupVersionKind::gvk(
+            group,
+            version,
+            reference.kind.as_ref()?,
+        ));
+        let api = Api::<DynamicObject>::namespaced_with(
+            client.clone(),
+            reference.namespace.as_ref()?,
+            &resource,
+        );
+        let mut control_plane = api.get(reference.name.as_ref()?).await.ok()?;
 
-        control_plane.status = None;
+        if let Some(data_object) = control_plane.data.as_object_mut() {
+            data_object.remove("status");
+        }
         control_plane.meta_mut().managed_fields = None;
+        control_plane.meta_mut().resource_version = None;
 
-        let mut infrastructure_cluster: Object<Value, Value> = client
-            .fetch(self.0.spec.infrastructure_ref.as_ref()?)
-            .await
-            .ok()?;
+        let infra_reference = self.0.spec.proxy.infrastructure_ref.as_ref()?;
+        let api_version = infra_reference.api_version.as_ref()?;
+        let (group, version) = api_version.split_once('/').unwrap_or(("", api_version));
+        let resource = ApiResource::from_gvk(&GroupVersionKind::gvk(
+            group,
+            version,
+            infra_reference.kind.as_ref()?,
+        ));
+        let api = Api::<DynamicObject>::namespaced_with(
+            client.clone(),
+            infra_reference.namespace.as_ref()?,
+            &resource,
+        );
+        let mut infrastructure_cluster = api.get(infra_reference.name.as_ref()?).await.ok()?;
 
-        infrastructure_cluster.status = None;
+        if let Some(data_object) = infrastructure_cluster.data.as_object_mut() {
+            data_object.remove("status");
+        }
         infrastructure_cluster.meta_mut().managed_fields = None;
+        infrastructure_cluster.meta_mut().resource_version = None;
 
         let values = TemplateValues {
             cluster,
@@ -112,21 +141,18 @@ impl FleetBundle for FleetClusterBundle {
 
                 let class_namespace = mapping.namespace().unwrap_or_default();
                 let cluster_namespace = mapping.name_any();
-                info!("Updated BundleNamespaceMapping for cluster {cluster_name} between class namespace: {class_namespace} and cluster namespace: {cluster_namespace}")
+                info!("Updated BundleNamespaceMapping for cluster {cluster_name} between class namespace: {class_namespace} and cluster namespace: {cluster_namespace}");
             };
         }
 
-        match self.config.cluster_patch_enabled() {
-            true => {
-                patch(
-                    ctx.clone(),
-                    cluster,
-                    &PatchParams::apply("addon-provider-fleet"),
-                )
-                .await?
-            }
-            false => get_or_create(ctx.clone(), cluster).await?,
-        };
+        if self.config.cluster_patch_enabled() {
+            patch(
+                ctx.clone(),
+                cluster,
+                &PatchParams::apply("addon-provider-fleet"),
+            )
+            .await?
+        } else { get_or_create(ctx.clone(), cluster).await? };
 
         #[cfg(feature = "agent-initiated")]
         if let Some(cluster_registration_token) = self.cluster_registration_token.as_ref() {
@@ -171,7 +197,7 @@ impl FleetBundle for FleetClusterBundle {
             }
 
             Api::<BundleNamespaceMapping>::namespaced(ctx.client.clone(), &ns.unwrap_or_default())
-                .delete(&mapping.name_any(), &Default::default())
+                .delete(&mapping.name_any(), &DeleteParams::default())
                 .await?;
         }
 
@@ -207,6 +233,7 @@ impl FleetController for Cluster {
 }
 
 impl Cluster {
+    #[must_use]
     pub fn cluster_ready(&self) -> Option<&Self> {
         let status = self.status.clone()?;
         let cp_ready = status.control_plane_ready.filter(|&ready| ready);
@@ -217,6 +244,11 @@ impl Cluster {
         ready_condition.or(cp_ready).map(|_| self)
     }
 
+    /// Adds a dynamic watcher for a specific namespace.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the watcher cannot be created or added to the stream.
     pub async fn add_namespace_dynamic_watch(
         ns: Arc<Namespace>,
         ctx: Arc<Context>,

--- a/src/controllers/cluster_class.rs
+++ b/src/controllers/cluster_class.rs
@@ -22,16 +22,15 @@ pub struct FleetClusterClassBundle {
 impl FleetBundle for FleetClusterClassBundle {
     #[allow(refining_impl_trait)]
     async fn sync(&mut self, ctx: Arc<Context>) -> GroupSyncResult<Action> {
-        match self.config.cluster_class_patch_enabled() {
-            true => {
-                patch(
-                    ctx,
-                    &mut self.fleet_group,
-                    &PatchParams::apply("addon-provider-fleet"),
-                )
-                .await?
-            }
-            false => get_or_create(ctx.clone(), &self.fleet_group).await?,
+        if self.config.cluster_class_patch_enabled() {
+            patch(
+                ctx,
+                &mut self.fleet_group,
+                &PatchParams::apply("addon-provider-fleet"),
+            )
+            .await?
+        } else {
+            get_or_create(ctx.clone(), &self.fleet_group).await?
         };
 
         Ok(Action::await_change())
@@ -54,7 +53,7 @@ impl FleetController for ClusterClass {
         }) = config.spec.cluster_class
         {
         } else {
-            fleet_group.metadata.owner_references = None
+            fleet_group.metadata.owner_references = None;
         }
 
         Ok(Some(FleetClusterClassBundle {

--- a/src/controllers/cluster_group.rs
+++ b/src/controllers/cluster_group.rs
@@ -1,6 +1,6 @@
+use crate::api::capi_clusterclass::ClusterClass;
 use crate::api::fleet_clustergroup::ClusterGroup;
 
-use cluster_api_rs::capi_clusterclass::ClusterClass;
 use kube::api::{Patch, PatchParams};
 use kube::runtime::controller::Action;
 use kube::{Api, ResourceExt};
@@ -13,6 +13,11 @@ use super::controller::{patch, Context, FLEET_FINALIZER};
 use super::{GroupSyncResult, SyncError};
 
 impl ClusterGroup {
+    /// Reconciles the `ClusterGroup` resource.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the sync operation fails.
     pub async fn reconcile(self: Arc<Self>, ctx: Arc<Context>) -> crate::Result<Action> {
         let mut group = self.deref().clone();
         Ok(group.sync(ctx).await.map_err(SyncError::from)?)
@@ -42,7 +47,7 @@ impl ClusterGroup {
                 Api::namespaced(ctx.client.clone(), &self.namespace().unwrap_or_default());
             api.patch(
                 &self.name_any(),
-                &Default::default(),
+                &PatchParams::default(),
                 &Patch::Merge(json!({"metadata": {"finalizers": self.finalizers()}})),
             )
             .await?;

--- a/src/controllers/controller.rs
+++ b/src/controllers/controller.rs
@@ -105,7 +105,7 @@ where
         // Ignore forbidden errors on namespace deletion
         Err(kube::Error::Api(e)) if &e.reason == "Forbidden" => (),
         e => e?,
-    };
+    }
 
     Ok(Action::await_change())
 }
@@ -156,7 +156,7 @@ where
         // Ignore forbidden errors on namespace deletion
         Err(kube::Error::Api(e)) if &e.reason == "Forbidden" => (),
         e => e?,
-    };
+    }
 
     Ok(Action::await_change())
 }
@@ -238,7 +238,7 @@ where
             // Ignore forbidden errors on namespace deletion
             Err(kube::Error::Api(e)) if &e.reason == "Forbidden" => (),
             e => e?,
-        };
+        }
 
         Ok(Action::await_change())
     }

--- a/src/controllers/controller.rs
+++ b/src/controllers/controller.rs
@@ -55,7 +55,7 @@ pub struct Context {
     pub barrier: Arc<Barrier>,
 }
 
-#[instrument(skip_all, fields(name = res.name_any(), namespace = res.namespace(), api_version = typed_gvk::<R>(()).api_version(), kind = R::kind(&()).to_string()), err)]
+#[instrument(skip_all, fields(name = res.name_any(), namespace = res.namespace(), api_version = typed_gvk::<R>(&()).api_version(), kind = R::kind(&()).to_string()), err)]
 pub(crate) async fn get_or_create<R>(ctx: Arc<Context>, res: &R) -> GetOrCreateResult<Action>
 where
     R: std::fmt::Debug,
@@ -110,7 +110,7 @@ where
     Ok(Action::await_change())
 }
 
-#[instrument(skip_all, fields(name = res.name_any(), namespace = res.namespace(), api_version = typed_gvk::<R>(()).api_version(), kind = R::kind(&()).to_string()), err)]
+#[instrument(skip_all, fields(name = res.name_any(), namespace = res.namespace(), api_version = typed_gvk::<R>(&()).api_version(), kind = R::kind(&()).to_string()), err)]
 pub(crate) async fn patch<R>(
     ctx: Arc<Context>,
     res: &mut R,
@@ -170,6 +170,7 @@ pub(crate) async fn fetch_config(client: Client) -> ConfigFetchResult<FleetAddon
 
 pub(crate) trait FleetBundle {
     async fn sync(&mut self, ctx: Arc<Context>) -> Result<Action, impl Into<SyncError>>;
+    #[allow(clippy::unused_async)]
     async fn cleanup(&mut self, _ctx: Arc<Context>) -> Result<Action, SyncError> {
         Ok(Action::await_change())
     }

--- a/src/controllers/helm/install.rs
+++ b/src/controllers/helm/install.rs
@@ -10,6 +10,7 @@ use super::{
     RepoUpdateResult,
 };
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Default, Clone)]
 pub struct FleetChart {
     pub repo: String,
@@ -55,18 +56,33 @@ pub struct ChartSearch {
 }
 
 impl FleetChart {
+    /// Adds the fleet helm repository.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the helm command fails to spawn.
     pub fn add_repo(&self) -> RepoAddResult<Child> {
         Ok(Command::new("helm")
             .args(["repo", "add", "fleet", &self.repo])
             .spawn()?)
     }
 
+    /// Updates the fleet helm repository.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the helm command fails to spawn.
     pub fn update_repo(&self) -> RepoUpdateResult<Child> {
         Ok(Command::new("helm")
             .args(["repo", "update", "fleet"])
             .spawn()?)
     }
 
+    /// Searches the fleet helm repository for charts.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the helm command fails to spawn or the output cannot be parsed.
     pub async fn search_repo(&self) -> RepoSearchResult<Vec<ChartSearch>> {
         let result = Command::new("helm")
             .stdout(Stdio::piped())
@@ -79,6 +95,11 @@ impl FleetChart {
         Ok(serde_json::from_str(output)?)
     }
 
+    /// Gets metadata for a specific chart.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the helm command fails to spawn or the output cannot be parsed.
     pub async fn get_metadata(chart: &str) -> MetadataGetResult<Option<ChartInfo>> {
         let mut metadata = Command::new("helm");
         metadata.args(["list", "-A", "-o", "json"]);
@@ -99,6 +120,11 @@ impl FleetChart {
         Ok(infos.into_iter().find(|i| i.name == chart))
     }
 
+    /// Installs or upgrades the fleet chart.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the helm command fails to spawn.
     pub fn fleet(&self, operation: &HelmOperation) -> FleetInstallResult<Child> {
         let mut install = Command::new("helm");
 
@@ -147,6 +173,11 @@ impl FleetChart {
         Ok(install.spawn()?)
     }
 
+    /// Installs or upgrades the fleet-crd chart.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the helm command fails to spawn.
     pub fn fleet_crds(&self, operation: &HelmOperation) -> FleetCRDInstallResult<Child> {
         let mut install = Command::new("helm");
 

--- a/src/crdgen.rs
+++ b/src/crdgen.rs
@@ -5,5 +5,5 @@ fn main() {
     print!(
         "{}",
         serde_yaml::to_string(&FleetAddonConfig::crd()).unwrap()
-    )
+    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ async fn index(c: Data<State>, _req: HttpRequest) -> impl Responder {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    telemetry::init().await;
+    telemetry::init();
 
     let client = Client::try_default()
         .await
@@ -44,38 +44,34 @@ async fn main() -> anyhow::Result<()> {
             .expect("version parse successfully"),
     );
 
-    match state.flags.helm_install {
-        true => {
-            let helm_install_controller = controller::run_fleet_helm_controller(state.clone());
-            tokio::join!(helm_install_controller);
-        }
-        false => {
-            let fleet_config_controller =
-                controller::run_fleet_addon_config_controller(state.clone());
-            let cluster_controller = controller::run_cluster_controller(state.clone());
-            let cluster_class_controller = controller::run_cluster_class_controller(state.clone());
+    if state.flags.helm_install {
+        let helm_install_controller = controller::run_fleet_helm_controller(state.clone());
+        tokio::join!(helm_install_controller);
+    } else {
+        let fleet_config_controller = controller::run_fleet_addon_config_controller(state.clone());
+        let cluster_controller = controller::run_cluster_controller(state.clone());
+        let cluster_class_controller = controller::run_cluster_class_controller(state.clone());
 
-            // Start web server
-            let server = HttpServer::new(move || {
-                App::new()
-                    .app_data(Data::new(state.clone()))
-                    .wrap(middleware::Logger::default().exclude("/health"))
-                    .service(index)
-                    .service(health)
-                    .service(metrics)
-            })
-            .bind("0.0.0.0:8443")?
-            .shutdown_timeout(5)
-            .run();
+        // Start web server
+        let server = HttpServer::new(move || {
+            App::new()
+                .app_data(Data::new(state.clone()))
+                .wrap(middleware::Logger::default().exclude("/health"))
+                .service(index)
+                .service(health)
+                .service(metrics)
+        })
+        .bind("0.0.0.0:8443")?
+        .shutdown_timeout(5)
+        .run();
 
-            tokio::join!(
-                cluster_controller,
-                cluster_class_controller,
-                fleet_config_controller,
-                server
-            )
-            .3?;
-        }
+        tokio::join!(
+            cluster_controller,
+            cluster_class_controller,
+            fleet_config_controller,
+            server
+        )
+        .3?;
     };
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,6 @@ async fn main() -> anyhow::Result<()> {
             server
         )
         .3?;
-    };
+    }
     Ok(())
 }

--- a/src/multi_dispatcher.rs
+++ b/src/multi_dispatcher.rs
@@ -144,7 +144,7 @@ where
             rx,
             // Initialize a ready store by default
             store: {
-                let mut store: Writer<K> = Default::default();
+                let mut store: Writer<K> = Writer::default();
                 store.apply_watcher_event(&Event::InitDone);
                 store
             },
@@ -161,8 +161,8 @@ pub fn gvk(obj: &DynamicObject) -> Option<GroupVersionKind> {
     gvk.try_into().ok()
 }
 
-pub fn typed_gvk<K: Resource>(dt: K::DynamicType) -> GroupVersionKind {
-    GroupVersionKind::gvk(&K::group(&dt), &K::version(&dt), &K::kind(&dt))
+pub fn typed_gvk<K: Resource>(dt: &K::DynamicType) -> GroupVersionKind {
+    GroupVersionKind::gvk(&K::group(dt), &K::version(dt), &K::kind(dt))
 }
 
 impl<K> Stream for TypedReflectHandle<K>
@@ -180,7 +180,7 @@ where
                 Some(event) => {
                     let obj = match event {
                         Event::InitApply(obj) | Event::Apply(obj)
-                            if gvk(&obj) == Some(typed_gvk::<K>(Default::default())) =>
+                            if gvk(&obj) == Some(typed_gvk::<K>(&Default::default())) =>
                         {
                             obj.try_parse::<K>()
                                 .ok()
@@ -190,7 +190,7 @@ where
                                 .map(Arc::new)
                         }
                         Event::Delete(obj)
-                            if gvk(&obj) == Some(typed_gvk::<K>(Default::default())) =>
+                            if gvk(&obj) == Some(typed_gvk::<K>(&Default::default())) =>
                         {
                             obj.try_parse::<K>()
                                 .ok()


### PR DESCRIPTION
This change addresses a maintainability issue in the addon-provider-fleet where updating `kube` or `k8s-openapi` versions required simultaneous updates across `fleet-api-rs` and `cluster-api-rs`, before being applied to the code.

The refactoring removes this dependency. The version of kube used in addon-provider-fleet is now consistently the one responsible for generating the cluster resource definitions (CRDs) for every component.

This allows dependent PRs to be merged independently of external API updates, significantly reducing maintenance pressure. It also cleans up the code and fixes the linter issues.
