### PR TITLE
bug: Add controller readiness barrier

### DIFF
--- a/src/controllers/controller.rs
+++ b/src/controllers/controller.rs
@@ -23,7 +23,7 @@ use tracing::field::display;
 use std::fmt::Debug;
 use std::pin::Pin;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{Barrier, RwLock};
 use tracing::{self, debug, info, instrument, Span};
 
 use super::{
@@ -51,6 +51,8 @@ pub struct Context {
     pub stream: BroadcastStream<DynamicStream>,
     // k8s minor version
     pub version: u32,
+    // Controller readiness barrier
+    pub barrier: Arc<Barrier>,
 }
 
 #[instrument(skip_all, fields(name = res.name_any(), namespace = res.namespace(), api_version = typed_gvk::<R>(()).api_version(), kind = R::kind(&()).to_string()), err)]

--- a/src/multi_dispatcher.rs
+++ b/src/multi_dispatcher.rs
@@ -3,7 +3,6 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
-    time::Duration,
 };
 
 use async_broadcast::{InactiveReceiver, Receiver, Sender};
@@ -19,7 +18,6 @@ use kube::{
 };
 use pin_project::pin_project;
 use serde::de::DeserializeOwned;
-use tokio::time::sleep;
 
 #[derive(Clone)]
 pub struct MultiDispatcher {
@@ -71,11 +69,6 @@ impl MultiDispatcher {
                 let _ = self.dispatch_tx.broadcast_direct(ev.clone()).await;
             }
         }
-    }
-
-    // Subscribers count returns the number of current receiving streams
-    pub(crate) fn subscribers_count(&self) -> usize {
-        self.dispatch_tx.receiver_count()
     }
 }
 
@@ -230,10 +223,6 @@ where
     W: Stream<Item = Result<Event<DynamicObject>>> + Unpin,
 {
     stream! {
-        while writer.subscribers_count() == 0 {
-            sleep(Duration::from_millis(100)).await;
-        }
-
         while let Some(event) = broadcast.next().await {
             match event {
                 Ok(ev) => {


### PR DESCRIPTION
Introduce a `tokio::sync::Barrier` to the shared controller state. Each main controller waits on this barrier after completing its initial setup, including dynamic watch registration and initial reconciliation. This dynamic watch polling will wait to synchronize and get ready for all core controllers before proceeding.

Fix #306 