### PR TITLE
[release-0.10] Perform `ResourceDiff` compare before patch (#317)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "chrono",
  "clap",
  "cluster-api-rs",
+ "educe",
  "fleet-api-rs",
  "futures",
  "http 1.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ fleet-api-rs = "0.12.3"
 async-broadcast = "0.7.2"
 pin-project = "1.1.10"
 async-stream = "0.3.6"
+educe = { version = "0.6.0", features = ["PartialEq"] }
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/src/api/bundle_namespace_mapping.rs
+++ b/src/api/bundle_namespace_mapping.rs
@@ -2,10 +2,12 @@ use fleet_api_rs::fleet_bundle_namespace_mapping::{
     BundleNamespaceMappingBundleSelector, BundleNamespaceMappingNamespaceSelector,
 };
 use kube::{
-    api::{ObjectMeta, TypeMeta},
     Resource,
+    api::{ObjectMeta, TypeMeta},
 };
 use serde::{Deserialize, Serialize};
+
+use crate::api::comparable::ResourceDiff;
 
 mod mapping {
     use kube::CustomResource;
@@ -31,4 +33,10 @@ pub struct BundleNamespaceMapping {
     pub metadata: ObjectMeta,
     pub bundle_selector: BundleNamespaceMappingBundleSelector,
     pub namespace_selector: BundleNamespaceMappingNamespaceSelector,
+}
+
+impl ResourceDiff for BundleNamespaceMapping {
+    fn diff(&self, other: &Self) -> bool {
+        self != other
+    }
 }

--- a/src/api/capi_cluster.rs
+++ b/src/api/capi_cluster.rs
@@ -8,8 +8,8 @@ use fleet_api_rs::{
     fleet_clustergroup::{ClusterGroupSelector, ClusterGroupSpec},
 };
 use kube::{
-    api::{ObjectMeta, TypeMeta},
     CustomResource, Resource, ResourceExt as _,
+    api::{ObjectMeta, TypeMeta},
 };
 #[cfg(feature = "agent-initiated")]
 use rand::distr::{Alphanumeric, SampleString as _};
@@ -20,7 +20,7 @@ use super::{
     bundle_namespace_mapping::BundleNamespaceMapping,
     fleet_addon_config::ClusterConfig,
     fleet_cluster,
-    fleet_clustergroup::{ClusterGroup, CLUSTER_CLASS_LABEL, CLUSTER_CLASS_NAMESPACE_LABEL},
+    fleet_clustergroup::{CLUSTER_CLASS_LABEL, CLUSTER_CLASS_NAMESPACE_LABEL, ClusterGroup},
 };
 
 #[cfg(feature = "agent-initiated")]

--- a/src/api/comparable.rs
+++ b/src/api/comparable.rs
@@ -1,0 +1,6 @@
+// Trait for resources that can be compared
+pub(crate) trait ResourceDiff: kube::ResourceExt {
+    fn diff(&self, other: &Self) -> bool {
+        self.meta() != other.meta()
+    }
+}

--- a/src/api/fleet_cluster.rs
+++ b/src/api/fleet_cluster.rs
@@ -1,9 +1,12 @@
 use fleet_api_rs::fleet_cluster::{ClusterSpec, ClusterStatus};
 use kube::{
+    Resource, ResourceExt,
     api::{ObjectMeta, TypeMeta},
-    Resource,
 };
 use serde::{Deserialize, Serialize};
+
+use crate::api::comparable::ResourceDiff;
+use std::collections::HashSet;
 
 #[derive(Resource, Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 #[resource(inherit = fleet_api_rs::fleet_cluster::Cluster)]
@@ -13,4 +16,61 @@ pub struct Cluster {
     pub metadata: ObjectMeta,
     pub spec: ClusterSpec,
     pub status: Option<ClusterStatus>,
+}
+
+impl ResourceDiff for Cluster {
+    fn diff(&self, other: &Self) -> bool {
+        // Resource was just created
+        if other.status.is_none() {
+            return true;
+        }
+
+        let template_values_equal = self
+            .spec
+            .template_values
+            .as_ref()
+            .unwrap_or(&std::collections::BTreeMap::new())
+            .iter()
+            .all(|(k, v)| {
+                other
+                    .spec
+                    .template_values
+                    .as_ref()
+                    .unwrap_or(&std::collections::BTreeMap::new())
+                    .get(k)
+                    == Some(v)
+            });
+
+        let spec_equal = template_values_equal
+            && self.spec.agent_namespace == other.spec.agent_namespace
+            && self.spec.host_network == other.spec.host_network
+            && self.spec.agent_env_vars == other.spec.agent_env_vars
+            && self.spec.agent_tolerations == other.spec.agent_tolerations;
+
+        if !spec_equal {
+            return true;
+        }
+
+        let annotations_equal = self
+            .annotations()
+            .iter()
+            .all(|(k, v)| other.annotations().get(k) == Some(v));
+        let labels_equal = self
+            .labels()
+            .iter()
+            .all(|(k, v)| other.labels().get(k) == Some(v));
+
+        let owner_uids: HashSet<String> = other
+            .owner_references()
+            .iter()
+            .map(|r| &r.uid)
+            .cloned()
+            .collect();
+        let owner_references_equal = self
+            .owner_references()
+            .iter()
+            .all(|self_ref| owner_uids.contains(&self_ref.uid));
+
+        !annotations_equal || !labels_equal || !owner_references_equal
+    }
 }

--- a/src/api/fleet_cluster_registration_token.rs
+++ b/src/api/fleet_cluster_registration_token.rs
@@ -2,10 +2,12 @@ use fleet_api_rs::fleet_cluster_registration_token::{
     ClusterRegistrationTokenSpec, ClusterRegistrationTokenStatus,
 };
 use kube::{
-    api::{ObjectMeta, TypeMeta},
     Resource,
+    api::{ObjectMeta, TypeMeta},
 };
 use serde::{Deserialize, Serialize};
+
+use crate::api::comparable::ResourceDiff;
 
 #[derive(Resource, Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 #[resource(inherit = fleet_api_rs::fleet_cluster_registration_token::ClusterRegistrationToken)]
@@ -15,4 +17,10 @@ pub struct ClusterRegistrationToken {
     pub metadata: ObjectMeta,
     pub spec: ClusterRegistrationTokenSpec,
     pub status: Option<ClusterRegistrationTokenStatus>,
+}
+
+impl ResourceDiff for ClusterRegistrationToken {
+    fn diff(&self, other: &Self) -> bool {
+        self.spec != other.spec
+    }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,6 +1,7 @@
 pub mod bundle_namespace_mapping;
 pub mod capi_cluster;
 pub mod capi_clusterclass;
+pub mod comparable;
 pub mod fleet_addon_config;
 pub mod fleet_cluster;
 #[cfg(feature = "agent-initiated")]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -5,9 +5,9 @@ use crate::api::fleet_addon_config::FleetAddonConfig;
 use crate::api::fleet_cluster;
 use crate::api::fleet_clustergroup::ClusterGroup;
 use crate::controllers::addon_config::FleetConfig;
-use crate::controllers::controller::{fetch_config, Context, DynamicStream, FleetController};
+use crate::controllers::controller::{Context, DynamicStream, FleetController, fetch_config};
 use crate::metrics::Diagnostics;
-use crate::multi_dispatcher::{broadcaster, BroadcastStream, MultiDispatcher};
+use crate::multi_dispatcher::{BroadcastStream, MultiDispatcher, broadcaster};
 use crate::{Error, Metrics};
 
 use chrono::Local;
@@ -17,9 +17,10 @@ use futures::{Stream, StreamExt};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, Time};
 use kube::api::{Patch, PatchParams};
 use kube::core::DeserializeGuard;
-use kube::runtime::reflector::store::Writer;
 use kube::runtime::reflector::ObjectRef;
-use kube::runtime::{metadata_watcher, predicates, reflector, watcher, WatchStreamExt};
+use kube::runtime::reflector::store::Writer;
+use kube::runtime::{WatchStreamExt, metadata_watcher, predicates, reflector, watcher};
+use kube::{Resource, ResourceExt};
 use kube::{
     api::Api,
     client::Client,
@@ -28,7 +29,6 @@ use kube::{
         watcher::Config,
     },
 };
-use kube::{Resource, ResourceExt};
 use tokio::sync::Barrier;
 
 use std::collections::BTreeMap;

--- a/src/controllers/cluster.rs
+++ b/src/controllers/cluster.rs
@@ -16,8 +16,8 @@ use kube::api::{
 
 use kube::client::scope;
 use kube::runtime::watcher::{self, Config};
-use kube::{api::ResourceExt, runtime::controller::Action, Resource};
 use kube::{Api, Client};
+use kube::{Resource, api::ResourceExt, runtime::controller::Action};
 use serde::Serialize;
 use serde_json::Value;
 use tracing::info;
@@ -25,7 +25,7 @@ use tracing::info;
 use std::sync::Arc;
 
 use super::controller::{
-    fetch_config, get_or_create, patch, Context, FleetBundle, FleetController,
+    Context, FleetBundle, FleetController, fetch_config, get_or_create, patch,
 };
 use super::{BundleResult, ClusterSyncError, ClusterSyncResult};
 
@@ -141,7 +141,9 @@ impl FleetBundle for FleetClusterBundle {
 
                 let class_namespace = mapping.namespace().unwrap_or_default();
                 let cluster_namespace = mapping.name_any();
-                info!("Updated BundleNamespaceMapping for cluster {cluster_name} between class namespace: {class_namespace} and cluster namespace: {cluster_namespace}");
+                info!(
+                    "Updated BundleNamespaceMapping for cluster {cluster_name} between class namespace: {class_namespace} and cluster namespace: {cluster_namespace}"
+                );
             }
         }
 
@@ -152,7 +154,9 @@ impl FleetBundle for FleetClusterBundle {
                 &PatchParams::apply("addon-provider-fleet"),
             )
             .await?
-        } else { get_or_create(ctx.clone(), cluster).await? };
+        } else {
+            get_or_create(ctx.clone(), cluster).await?
+        };
 
         #[cfg(feature = "agent-initiated")]
         if let Some(cluster_registration_token) = self.cluster_registration_token.as_ref() {

--- a/src/controllers/cluster_class.rs
+++ b/src/controllers/cluster_class.rs
@@ -10,7 +10,7 @@ use kube::runtime::controller::Action;
 use std::sync::Arc;
 
 use super::controller::{
-    fetch_config, get_or_create, patch, Context, FleetBundle, FleetController,
+    Context, FleetBundle, FleetController, fetch_config, get_or_create, patch,
 };
 use super::{BundleResult, GroupSyncResult};
 

--- a/src/controllers/cluster_group.rs
+++ b/src/controllers/cluster_group.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 use std::ops::Deref;
 use std::sync::Arc;
 
-use super::controller::{patch, Context, FLEET_FINALIZER};
+use super::controller::{Context, FLEET_FINALIZER, patch};
 use super::{GroupSyncResult, SyncError};
 
 impl ClusterGroup {

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -84,6 +84,9 @@ pub type PatchResult<T, E = PatchError> = std::result::Result<T, E>;
 
 #[derive(Error, Debug)]
 pub enum PatchError {
+    #[error("Get error: {0}")]
+    Get(#[source] kube::Error),
+
     #[error("Patch error: {0}")]
     Patch(#[source] kube::Error),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
 use std::io;
 
 use controllers::{
-    addon_config::{AddonConfigSyncError, DynamicWatcherError, FleetPatchError},
-    helm, BundleError, SyncError,
+    BundleError, SyncError,
+    addon_config::{
+        AddonConfigSyncError, DynamicWatcherError, FleetPatchError, ReconcileConfigSyncError,
+    },
+    helm,
 };
 use futures::channel::mpsc::TrySendError;
 use thiserror::Error;
@@ -38,6 +41,9 @@ pub enum Error {
 
     #[error("Dynamic watcher error: {0}")]
     DynamicWatcherError(#[from] DynamicWatcherError),
+
+    #[error("Reconcile config sync error: {0}")]
+    ReconcileConfigSync(#[from] ReconcileConfigSyncError),
 
     #[error("Namespace trigger error: {0}")]
     TriggerError(#[from] TrySendError<()>),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use actix_web::{
-    get, middleware, web::Data, App, HttpRequest, HttpResponse, HttpServer, Responder,
+    App, HttpRequest, HttpResponse, HttpServer, Responder, get, middleware, web::Data,
 };
-pub use controller::{self, telemetry, State};
+pub use controller::{self, State, telemetry};
 use kube::Client;
 use prometheus::{Encoder, TextEncoder};
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 use crate::Error;
 use chrono::{DateTime, Utc};
 use kube::{
-    runtime::events::{Recorder, Reporter},
     Client, ResourceExt,
+    runtime::events::{Recorder, Reporter},
 };
-use prometheus::{histogram_opts, opts, HistogramVec, IntCounter, IntCounterVec, Registry};
+use prometheus::{HistogramVec, IntCounter, IntCounterVec, Registry, histogram_opts, opts};
 use serde::Serialize;
 use tokio::time::Instant;
 

--- a/src/multi_dispatcher.rs
+++ b/src/multi_dispatcher.rs
@@ -7,14 +7,14 @@ use std::{
 
 use async_broadcast::{InactiveReceiver, Receiver, Sender};
 use async_stream::stream;
-use futures::{lock::Mutex, ready, Stream, StreamExt as _};
+use futures::{Stream, StreamExt as _, lock::Mutex, ready};
 use kube::{
+    Resource,
     api::{DynamicObject, GroupVersionKind},
     runtime::{
-        reflector::{store::Writer, Lookup, Store},
+        reflector::{Lookup, Store, store::Writer},
         watcher::{Event, Result},
     },
-    Resource,
 };
 use pin_project::pin_project;
 use serde::de::DeserializeOwned;

--- a/src/predicates.rs
+++ b/src/predicates.rs
@@ -1,5 +1,5 @@
-use kube::runtime::predicates;
 use kube::ResourceExt;
+use kube::runtime::predicates;
 
 pub fn generation_with_deletion(obj: &impl ResourceExt) -> Option<u64> {
     match obj.meta().deletion_timestamp {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,5 +1,5 @@
 use opentelemetry::trace::TraceId;
-use tracing_subscriber::{prelude::*, EnvFilter, Registry};
+use tracing_subscriber::{EnvFilter, Registry, prelude::*};
 
 ///  Fetch an `opentelemetry::trace::TraceId` as hex through the full tracing stack
 #[must_use]


### PR DESCRIPTION
* Fmt fixes



* Implement custom resource comparison logic

Introduces a `ResourceDiff` trait and implements it for various Fleet API resources. This allows controllers to perform more granular comparisons between the desired state and the current state of resources, avoiding unnecessary updates and reconciliations.



* Improve readability of the wait conditions individually



---------