### PR TITLE
fix: Add fleet annotation to namespace of CAPI cluster

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -349,10 +349,21 @@ pub async fn run_cluster_controller(state: State) {
         .default_backoff()
         .for_each(|_| futures::future::ready(()));
 
+    let cluster_ns_controller = Controller::new(
+        Api::<Cluster>::all(client.clone()),Default::default())
+        .shutdown_on_signal()
+        .run(
+            Cluster::reconcile_fleet_annotation_in_capi_ns,
+            error_policy,
+            state.to_context(client.clone()),
+        )
+        .default_backoff()
+        .for_each(|_| futures::future::ready(()));
+
     // Signal that this controller is ready
     state.barrier.wait().await;
 
-    tokio::join!(clusters, ns_controller);
+    tokio::join!(clusters, ns_controller, cluster_ns_controller);
 }
 
 /// Initialize the controller and shared state (given the crd is installed)

--- a/src/controllers/cluster.rs
+++ b/src/controllers/cluster.rs
@@ -17,10 +17,11 @@ use kube::api::{
 use kube::client::scope;
 use kube::runtime::watcher::{self, Config};
 use kube::{Api, Client};
-use kube::{Resource, api::ResourceExt, runtime::controller::Action};
+use kube::{Resource, api::{ResourceExt, Patch}, runtime::controller::Action};
 use serde::Serialize;
 use serde_json::Value;
-use tracing::info;
+use serde_json::json;
+use tracing::{info,debug};
 
 use std::sync::Arc;
 
@@ -30,6 +31,7 @@ use super::controller::{
 use super::{BundleResult, ClusterSyncError, ClusterSyncResult};
 
 pub static CONTROLPLANE_READY_CONDITION: &str = "ControlPlaneReady";
+pub static FLEET_WORKSPACE_ANNOTATION: &str = "field.cattle.io/allow-fleetworkspace-creation-for-existing-namespace";
 
 pub struct FleetClusterBundle {
     template_sources: TemplateSources,
@@ -285,4 +287,49 @@ impl Cluster {
 
         Ok(Action::await_change())
     }
+
+    pub async fn reconcile_fleet_annotation_in_capi_ns(obj: Arc<Cluster>, ctx: Arc<Context>) -> crate::Result<Action> {
+        let deletion_timestamp = &obj.metadata.deletion_timestamp;
+        let namespace_name = obj.namespace().unwrap_or_default();
+        let namespaces = Api::<Namespace>::all(ctx.client.clone());
+
+        match deletion_timestamp {
+            // If the cluster is being deleted, and this is the last CAPI cluster in this namespace, remove the fleet annotation.
+            Some(_) => {
+                // List all other clusters in this namespace
+                let clusters = Api::<Cluster>::namespaced(ctx.client.clone(), &namespace_name);
+                let other_clusters = clusters
+                    .list(&ListParams::default().fields(&format!("metadata.namespace={},metadata.name!={}", namespace_name, obj.name_any())))
+                    .await?;
+
+                // If no other clusters are found in this namespace, remove the fleet annotation.
+                if other_clusters.items.is_empty() {
+                    let patch = json!({
+                        "metadata": {
+                            "annotations": {
+                                FLEET_WORKSPACE_ANNOTATION: null
+                            }
+                        }
+                    });
+                    namespaces.patch_metadata(&namespace_name,&PatchParams::default(), &Patch::Merge(&patch)).await?;
+                    debug!("Removed fleet annotation from namespace {}.", namespace_name);
+                } 
+            },
+            // If the cluster is not being deleted, ensure the fleet annotation is present.
+            None => {
+                let patch = json!({
+                        "metadata": {
+                            "annotations": {
+                                FLEET_WORKSPACE_ANNOTATION: "true"
+                            }
+                        }
+                    });
+                namespaces.patch_metadata(&namespace_name,&PatchParams::default(), &Patch::Merge(&patch)).await?;
+                debug!("Added fleet annotation to namespace {}.", namespace_name);
+            }   
+        }
+
+        Ok(Action::await_change())
+    }
 }
+


### PR DESCRIPTION
This is part of a fix for https://github.com/rancher/turtles/issues/1329

This PR adds a reconciler that ensures a fleet annotation (https://github.com/rancher/webhook/pull/932) is present in namespaces of CAPI clusters.