### PR TITLE
Use `ControlPlaneInitialized` condition to determine if cluster is ready to connect

### DIFF
--- a/justfile
+++ b/justfile
@@ -170,14 +170,14 @@ release-manifests: _create-out-dir _download-kustomize
 # Full e2e test of importing cluster in fleet
 test-import: start-dev deploy deploy-child-cluster deploy-kindnet deploy-app && collect-test-import
     kubectl wait pods --for=condition=Ready --timeout=150s --all --all-namespaces
-    kubectl wait cluster --timeout=500s --for=condition=ControlPlaneReady=true docker-demo
+    kubectl wait cluster --timeout=500s --for=condition=ControlPlaneInitialized=true docker-demo
     kubectl wait clusters.fleet.cattle.io --timeout=500s --for=condition=Ready=true docker-demo
     kubectl wait ns default --timeout=500s --for=jsonpath='{.metadata.annotations.field\.cattle\.io\/allow-fleetworkspace-creation-for-existing-namespace}=true'
 
 # Full e2e test of importing cluster in fleet
 test-import-rke2: start-dev deploy deploy-child-rke2-cluster deploy-calico-gitrepo deploy-app
     kubectl wait pods --for=condition=Ready --timeout=150s --all --all-namespaces
-    kubectl wait cluster --timeout=500s --for=condition=ControlPlaneReady=true docker-demo
+    kubectl wait cluster --timeout=500s --for=condition=ControlPlaneInitialized=true docker-demo
     kubectl wait clusters.fleet.cattle.io --timeout=500s --for=condition=Ready=true docker-demo
 
 collect-test-import:

--- a/src/controllers/cluster.rs
+++ b/src/controllers/cluster.rs
@@ -34,7 +34,7 @@ use super::controller::{
 };
 use super::{BundleResult, ClusterSyncError, ClusterSyncResult};
 
-pub static CONTROLPLANE_READY_CONDITION: &str = "ControlPlaneReady";
+pub static CONTROLPLANE_INITIALIZED_CONDITION: &str = "ControlPlaneInitialized";
 
 pub struct FleetClusterBundle {
     namespace: Namespace,
@@ -293,7 +293,7 @@ impl Cluster {
         let status = self.status.clone()?;
         let cp_ready = status.control_plane_ready.filter(|&ready| ready);
         let ready_condition = status.conditions?.iter().find_map(|c| {
-            (c.type_ == CONTROLPLANE_READY_CONDITION && c.status == "True").then_some(true)
+            (c.type_ == CONTROLPLANE_INITIALIZED_CONDITION && c.status == "True").then_some(true)
         });
 
         ready_condition.or(cp_ready).map(|_| self)


### PR DESCRIPTION
When using `ControlPlaneInitialized` condition, I was able to bring up a cluster with > 1 CP replicas with the Kubeadm provider.

Fixes https://github.com/rancher/turtles/issues/1402