### PR TITLE
ci: add release workflow using publish-image action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  publish-image:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: runs-on,runner=8cpu-linux-x64,run-id=${{ github.run_id }},image=ubuntu22-full-x64
+    steps:
+    - name: Check out code
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+
+    - name: "Read secrets"
+      uses: rancher-eio/read-vault-secrets@main
+      with:
+        secrets: |
+          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD ;
+
+    - name: Push image to public
+      uses: rancher/ecm-distro-tools/actions/publish-image@master
+      with:
+        image: cluster-api-addon-provider-fleet
+        tag: ${{ github.ref_name }}
+        platforms: linux/amd64,linux/arm64
+        push-to-prime: false
+        public-repo: rancher
+        public-username: ${{ env.DOCKER_USERNAME }}
+        public-password: ${{ env.DOCKER_PASSWORD }}
+        make-target: push-image
+
+    - name: Push image to prime
+      if: ${{ !contains(github.ref_name, '-rc') }}
+      uses: rancher/ecm-distro-tools/actions/publish-image@master
+      with:
+        image: cluster-api-addon-provider-fleet
+        tag: ${{ github.ref_name }}
+        platforms: linux/amd64,linux/arm64
+        push-to-public: false
+        prime-repo: rancher
+        prime-registry: ${{ env.PRIME_REGISTRY }}
+        prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
+        prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
+        prime-make-target: push-prime-image
+
+  release:
+    name: Create release
+    needs: publish-image
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+      with:
+        fetch-depth: 0
+    - name: Create GH release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release create ${{ github.ref_name }} --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,23 +19,9 @@ jobs:
       uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89
       with:
         secrets: |
-          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
-          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD ;
           secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
           secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
           secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD ;
-
-    - name: Push image to public
-      uses: rancher/ecm-distro-tools/actions/publish-image@5d6e63896fea85836b2fca6dfb9236bcefe2aaa5
-      with:
-        image: cluster-api-addon-provider-fleet
-        tag: ${{ github.ref_name }}
-        platforms: linux/amd64,linux/arm64
-        push-to-prime: false
-        public-repo: rancher
-        public-username: ${{ env.DOCKER_USERNAME }}
-        public-password: ${{ env.DOCKER_PASSWORD }}
-        make-target: push-image
 
     - name: Push image to prime
       if: ${{ !contains(github.ref_name, '-rc') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
 
     - name: "Read secrets"
-      uses: rancher-eio/read-vault-secrets@main
+      uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
@@ -26,7 +26,7 @@ jobs:
           secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD ;
 
     - name: Push image to public
-      uses: rancher/ecm-distro-tools/actions/publish-image@master
+      uses: rancher/ecm-distro-tools/actions/publish-image@5d6e63896fea85836b2fca6dfb9236bcefe2aaa5
       with:
         image: cluster-api-addon-provider-fleet
         tag: ${{ github.ref_name }}
@@ -39,7 +39,7 @@ jobs:
 
     - name: Push image to prime
       if: ${{ !contains(github.ref_name, '-rc') }}
-      uses: rancher/ecm-distro-tools/actions/publish-image@master
+      uses: rancher/ecm-distro-tools/actions/publish-image@5d6e63896fea85836b2fca6dfb9236bcefe2aaa5
       with:
         image: cluster-api-addon-provider-fleet
         tag: ${{ github.ref_name }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+MACHINE := rancher
+DEFAULT_PLATFORMS := linux/amd64,linux/arm64
+
+REPO ?= rancher
+IMAGE ?= cluster-api-addon-provider-fleet
+TAG ?= dev
+IMAGE_NAME ?= $(REPO)/$(IMAGE):$(TAG)
+
+.PHONY: buildx-machine
+buildx-machine: ## Create rancher buildx machine targeting DEFAULT_PLATFORMS.
+	@docker buildx ls | grep $(MACHINE) || \
+	  docker buildx create --name=$(MACHINE) --platform=$(DEFAULT_PLATFORMS)
+
+.PHONY: push-image
+push-image: ## Build and push multiarch image via docker buildx (called by publish-image action).
+	docker buildx build \
+	  $(IID_FILE_FLAG) \
+	  $(BUILDX_ARGS) \
+	  --platform=$(TARGET_PLATFORMS) \
+	  --tag $(IMAGE_NAME) \
+	  --push \
+	  .
+
+.PHONY: push-prime-image
+push-prime-image: ## Build and push multiarch image to prime registry with SBOM and provenance attestations.
+	BUILDX_ARGS="--sbom=true --attest type=provenance,mode=max" \
+	$(MAKE) push-image


### PR DESCRIPTION
## What changed

- Add release workflow pushing to DockerHub public and prime registry
- Guard prime pushes behind rc check to avoid pre-release images in prime
- Use `runs-on` 8cpu-linux-x64 runner as recommended by Rancher guidelines
- Read DockerHub and prime credentials from Vault via `rancher-eio/read-vault-secrets`
- Add `Makefile` with `push-image` and `push-prime-image` targets using `docker buildx`
- Add `buildx-machine`, `REPO`, `IMAGE` and `IMAGE_NAME` variables for publish-image compatibility