### PR TITLE
fix: release workflow fixes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   TAG: ${{ github.ref_name }}
-  IMAGE_NAME: cluster-api-addon-provider-fleet
+  IMAGE: cluster-api-addon-provider-fleet
   REPOSITORY_OWNER: ${{ github.repository_owner }}
   REGISTRY: ghcr.io
 
@@ -21,24 +21,17 @@ jobs:
       # - OIDC for cosign's use in ecm-distro-tools/publish-image
       # - Publish image to ghcr.io
       id-token: write
-    strategy:
-      matrix:
-        include:
-        - platform: linux/amd64
-          tag-suffix: "linux-amd64"
-        - platform: linux/arm64
-          tag-suffix: "linux-arm64"
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Push image to ghcr.io
-        uses: rancher/ecm-distro-tools/actions/publish-image@067de5ae5517b661b4d2f10e22cc5a21aa0ac915
+        uses: rancher/ecm-distro-tools/actions/publish-image@da9f5b6e258c327660eeab3db97952b612f1cf9f # v0.69.3
         with:
-          image: ${{ env.IMAGE_NAME }}
-          tag: ${{ env.TAG }}-${{ matrix.tag-suffix }}
-          platforms: ${{ matrix.platform }}
+          image: ${{ env.IMAGE }}
+          tag: ${{ env.TAG }}
+          platforms: linux/amd64,linux/arm64
           push-to-public: true
           push-to-prime: false
           public-registry: ${{ env.REGISTRY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # renovate: datasource=github-release-attachments depName=rust-lang/rustup
 ARG RUSTUP_VERSION=1.29.0
 # renovate: datasource=github-release-attachments depName=rust-lang/rustup digestVersion=1.29.0
-ARG RUSTUP_SUM_arm64=9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792
+ARG RUSTUP_SUM_arm64=88761caacddb92cd79b0b1f939f3990ba1997d701a38b3e8dd6746a562f2a759
 # renovate: datasource=github-release-attachments depName=rust-lang/rustup digestVersion=1.29.0
-ARG RUSTUP_SUM_amd64=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
+ARG RUSTUP_SUM_amd64=9cd3fda5fd293890e36ab271af6a786ee22084b5f6c2b83fd8323cec6f0992c1
 
 FROM --platform=${BUILDPLATFORM} ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5 AS build-arm64
 ARG BUILDPLATFORM
@@ -12,7 +12,7 @@ ARG RUSTUP_VERSION
 ARG RUSTUP_SUM_arm64
 
 RUN curl --proto '=https' --tlsv1.2 -sSfL -o /tmp/rustup-init \
-    "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/aarch64-unknown-linux-gnu/rustup-init" && \
+    "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/aarch64-unknown-linux-musl/rustup-init" && \
     echo "${RUSTUP_SUM_arm64}  /tmp/rustup-init" | sha256sum -c - && \
     chmod +x /tmp/rustup-init && \
     /tmp/rustup-init -y --target aarch64-unknown-linux-musl --default-toolchain stable && \
@@ -37,7 +37,7 @@ ARG RUSTUP_VERSION
 ARG RUSTUP_SUM_amd64
 
 RUN curl --proto '=https' --tlsv1.2 -sSfL -o /tmp/rustup-init \
-    "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init" && \
+    "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-musl/rustup-init" && \
     echo "${RUSTUP_SUM_amd64}  /tmp/rustup-init" | sha256sum -c - && \
     chmod +x /tmp/rustup-init && \
     /tmp/rustup-init -y --target x86_64-unknown-linux-musl --default-toolchain stable && \

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ IMAGE_NAME ?= $(REPO)/$(IMAGE):$(TAG)
 
 .PHONY: push-image
 push-image:
- docker buildx build \
-  $(IID_FILE_FLAG) \
-  $(BUILDX_ARGS) \
-  --platform=$(TARGET_PLATFORMS) \
-  --tag $(IMAGE_NAME) \
-  --push \
-  .
+	docker buildx build \
+		$(IID_FILE_FLAG) \
+		$(BUILDX_ARGS) \
+		--platform=$(TARGET_PLATFORMS) \
+		--tag $(IMAGE_NAME) \
+		--push \
+		.


### PR DESCRIPTION
A few fixes:
- Fixes incorrect glibc rustup binary introduced by https://github.com/rancher/cluster-api-addon-provider-fleet/pull/444
- Fixes incorrect image tagging and badly formatted makefile introduced by https://github.com/rancher/cluster-api-addon-provider-fleet/pull/454